### PR TITLE
ci(ci): 补充删除本地镜像过程

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
 						docker.withRegistry('https://192.168.0.62', 'harbor-jenkins') {
 							docker.image("${DOCKER_IMAGE}:${DOCKER_TAG}").push()
 						}
-						sh 'docker rmi ${DOCKER_IMAGE}:${DOCKER_TAG} || true'
+						sh 'docker rmi ${DOCKER_IMAGE}:${DOCKER_TAG}'
 					}
 				}
 			}


### PR DESCRIPTION
由于harbor已留存镜像，故删除本地镜像以减少磁盘空间，提高安全性。