### PR TITLE
perf: 优化镜像体积

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.2
+FROM alpine:3.23.2
 
 ARG CONSUL_HOST=127.0.0.1
 ARG CONSUL_PORT=8500
@@ -8,13 +8,16 @@ ENV CONSUL_HOST=$CONSUL_HOST \
 	CONSUL_PORT=$CONSUL_PORT \
 	CONSUL_PREFIX=$CONSUL_PREFIX
 
-COPY order /var/order
-
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
-    && apk add --no-cache tzdata \
-    && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
-    && chmod +x /var/order
+	&& apk add --no-cache tzdata \
+	&& ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 
-WORKDIR /var
+RUN addgroup -g 1002 app \
+	&& adduser -S -D -u 1002 -G app app
+
+COPY --chown=app:app --chmod=500 order /home/app/order
+
+WORKDIR /home/app
+USER app
 
 CMD [ "./order" ]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: build
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o order cmd/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o order cmd/main.go


### PR DESCRIPTION
resolves #152, #153, zhanshen02154/go-micro-service#43, zhanshen02154/go-micro-service#44

BREAKING CHANGE: 
- 强制使用非root用户运行
- 更新基础镜像为alpine:3.23.2
- 用make编译可执行文件